### PR TITLE
Removed warning about deprecated Config

### DIFF
--- a/lib/devil.rb
+++ b/lib/devil.rb
@@ -3,7 +3,11 @@
 require 'rbconfig'
 
 direc = File.dirname(__FILE__)
-dlext = Config::CONFIG['DLEXT']
+unless defined? ::RbConfig
+    dlext = Config::CONFIG['DLEXT']
+else
+    dlext = RbConfig::CONFIG['DLEXT']
+end
 
 begin
     if RUBY_VERSION && RUBY_VERSION =~ /1.9/


### PR DESCRIPTION
> >  devil-0.1.9.5/lib/devil.rb:6: Use RbConfig instead of obsolete
> >  and deprecated Config.
